### PR TITLE
Remove Top-Level Await From FileSystemWritableFileStream

### DIFF
--- a/src/FileSystemWritableFileStream.js
+++ b/src/FileSystemWritableFileStream.js
@@ -1,79 +1,66 @@
 /** @type {typeof WritableStream} */
-const ws =
-  globalThis.WritableStream ||
-  polyfill()
-    .then((r) => r.WritableStream)
-    .catch(() => import("web-streams-polyfill").then((r) => r.WritableStream));
+const ws = globalThis.WritableStream || polyfill().then((r) => r.WritableStream).catch(() => import("web-streams-polyfill").then((r) => r.WritableStream));
 
 async function polyfill() {
-  return await import(
-    "https://cdn.jsdelivr.net/npm/web-streams-polyfill@3/dist/ponyfill.es2018.mjs"
-  );
+  return await import("https://cdn.jsdelivr.net/npm/web-streams-polyfill@3/dist/ponyfill.es2018.mjs");
 }
-
 // TODO: add types for ws
 class FileSystemWritableFileStream extends ws {
-  constructor(...args) {
-    super(...args);
+  constructor (...args) {
+    super(...args)
 
     // Stupid Safari hack to extend native classes
     // https://bugs.webkit.org/show_bug.cgi?id=226201
-    Object.setPrototypeOf(this, FileSystemWritableFileStream.prototype);
+    Object.setPrototypeOf(this, FileSystemWritableFileStream.prototype)
 
     /** @private */
-    this._closed = false;
+    this._closed = false
   }
 
-  close() {
-    this._closed = true;
-    const w = this.getWriter();
-    const p = w.close();
-    w.releaseLock();
-    return p;
+  close () {
+    this._closed = true
+    const w = this.getWriter()
+    const p = w.close()
+    w.releaseLock()
+    return p
     // return super.close ? super.close() : this.getWriter().close()
   }
 
   /** @param {number} position */
-  seek(position) {
-    return this.write({ type: "seek", position });
+  seek (position) {
+    return this.write({ type: 'seek', position })
   }
 
   /** @param {number} size */
-  truncate(size) {
-    return this.write({ type: "truncate", size });
+  truncate (size) {
+    return this.write({ type: 'truncate', size })
   }
 
-  write(data) {
+  write (data) {
     if (this._closed) {
-      return Promise.reject(
-        new TypeError("Cannot write to a CLOSED writable stream")
-      );
+      return Promise.reject(new TypeError('Cannot write to a CLOSED writable stream'))
     }
 
-    const writer = this.getWriter();
-    const p = writer.write(data);
-    writer.releaseLock();
-    return p;
+    const writer = this.getWriter()
+    const p = writer.write(data)
+    writer.releaseLock()
+    return p
   }
 }
 
-Object.defineProperty(
-  FileSystemWritableFileStream.prototype,
-  Symbol.toStringTag,
-  {
-    value: "FileSystemWritableFileStream",
-    writable: false,
-    enumerable: false,
-    configurable: true,
-  }
-);
+Object.defineProperty(FileSystemWritableFileStream.prototype, Symbol.toStringTag, {
+  value: 'FileSystemWritableFileStream',
+  writable: false,
+  enumerable: false,
+  configurable: true
+})
 
 Object.defineProperties(FileSystemWritableFileStream.prototype, {
   close: { enumerable: true },
   seek: { enumerable: true },
   truncate: { enumerable: true },
-  write: { enumerable: true },
-});
+  write: { enumerable: true }
+})
 
-export default FileSystemWritableFileStream;
-export { FileSystemWritableFileStream };
+export default FileSystemWritableFileStream
+export { FileSystemWritableFileStream }

--- a/src/FileSystemWritableFileStream.js
+++ b/src/FileSystemWritableFileStream.js
@@ -1,63 +1,79 @@
 /** @type {typeof WritableStream} */
-const ws = globalThis.WritableStream || await import('https://cdn.jsdelivr.net/npm/web-streams-polyfill@3/dist/ponyfill.es2018.mjs').then(r => r.WritableStream).catch(() => import('web-streams-polyfill').then(r => r.WritableStream))
+const ws =
+  globalThis.WritableStream ||
+  polyfill()
+    .then((r) => r.WritableStream)
+    .catch(() => import("web-streams-polyfill").then((r) => r.WritableStream));
+
+async function polyfill() {
+  return await import(
+    "https://cdn.jsdelivr.net/npm/web-streams-polyfill@3/dist/ponyfill.es2018.mjs"
+  );
+}
 
 // TODO: add types for ws
 class FileSystemWritableFileStream extends ws {
-  constructor (...args) {
-    super(...args)
+  constructor(...args) {
+    super(...args);
 
     // Stupid Safari hack to extend native classes
     // https://bugs.webkit.org/show_bug.cgi?id=226201
-    Object.setPrototypeOf(this, FileSystemWritableFileStream.prototype)
+    Object.setPrototypeOf(this, FileSystemWritableFileStream.prototype);
 
     /** @private */
-    this._closed = false
+    this._closed = false;
   }
 
-  close () {
-    this._closed = true
-    const w = this.getWriter()
-    const p = w.close()
-    w.releaseLock()
-    return p
+  close() {
+    this._closed = true;
+    const w = this.getWriter();
+    const p = w.close();
+    w.releaseLock();
+    return p;
     // return super.close ? super.close() : this.getWriter().close()
   }
 
   /** @param {number} position */
-  seek (position) {
-    return this.write({ type: 'seek', position })
+  seek(position) {
+    return this.write({ type: "seek", position });
   }
 
   /** @param {number} size */
-  truncate (size) {
-    return this.write({ type: 'truncate', size })
+  truncate(size) {
+    return this.write({ type: "truncate", size });
   }
 
-  write (data) {
+  write(data) {
     if (this._closed) {
-      return Promise.reject(new TypeError('Cannot write to a CLOSED writable stream'))
+      return Promise.reject(
+        new TypeError("Cannot write to a CLOSED writable stream")
+      );
     }
 
-    const writer = this.getWriter()
-    const p = writer.write(data)
-    writer.releaseLock()
-    return p
+    const writer = this.getWriter();
+    const p = writer.write(data);
+    writer.releaseLock();
+    return p;
   }
 }
 
-Object.defineProperty(FileSystemWritableFileStream.prototype, Symbol.toStringTag, {
-  value: 'FileSystemWritableFileStream',
-  writable: false,
-  enumerable: false,
-  configurable: true
-})
+Object.defineProperty(
+  FileSystemWritableFileStream.prototype,
+  Symbol.toStringTag,
+  {
+    value: "FileSystemWritableFileStream",
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  }
+);
 
 Object.defineProperties(FileSystemWritableFileStream.prototype, {
   close: { enumerable: true },
   seek: { enumerable: true },
   truncate: { enumerable: true },
-  write: { enumerable: true }
-})
+  write: { enumerable: true },
+});
 
-export default FileSystemWritableFileStream
-export { FileSystemWritableFileStream }
+export default FileSystemWritableFileStream;
+export { FileSystemWritableFileStream };


### PR DESCRIPTION
Hey, I was running into issues using your library with webpack in a react app. It would work fine when running in development mode, but the production build would get stuck when trying to resolve your library.

I tracked the issue down to the top-level await in FileSystemWritableFileStream.js

After switching it over to using an async function I'm able to use it in production builds.

I appreciate what you've made here and figure this might help other people be able to use it. 