### PR TITLE
breaking: remove polyfills & top level await

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,35 @@ It's not trying to interfere with the changing spec by using other properties th
 ( The current minium supported browser I have chosen to support is the ones that can handle import/export )<br>
 ( Some parts are lazy loaded when needed )
 
+### Updating from 2.x to 3.x
+v3 removed all top level await that conditionally loaded polyfills like
+WritableStream, DOMException, and Blob/File. considering that now all latest
+up to date env have this built in globally on `globalThis` namespace. This makes
+the file system adapter lighter for ppl who want a smaller bundle and supports
+newer engines.
+
+But if you still need to provide polyfills for older environments
+then you can provide your own polyfill and set it up with our config before any
+other script is evaluated
+
+```js
+
+import config from 'native-file-system-adapter/config.js'
+// This is the default config that you could override as needed.
+Object.assign(config, {
+  ReadableStream: globalThis.ReadableStream,
+  WritableStream: globalThis.WritableStream,
+  TransformStream: globalThis.TransformStream,
+  DOMException: globalThis.DOMException,
+  Blob: globalThis.Blob,
+  File: globalThis.File
+})
+// continue like normal.
+import xyz from 'native-file-system-adapter'
+```
+
+
+
 ### ES import in browser
 
 ```html

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fetch-blob": "^3.1.5",
+        "fetch-blob": "*",
         "node-domexception": "^1.0.0"
       },
       "devDependencies": {
@@ -35,6 +35,7 @@
         "node": ">=14.8.0"
       },
       "optionalDependencies": {
+        "fetch-blob": "^3.2.0",
         "web-streams-polyfill": "^3.1.1"
       }
     },
@@ -1282,9 +1283,9 @@
       }
     },
     "node_modules/fetch-blob": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
       "funding": [
         {
           "type": "github",
@@ -1295,6 +1296,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "optional": true,
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -3466,6 +3468,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
       "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q==",
+      "optional": true,
       "engines": {
         "node": ">= 8"
       }
@@ -4517,9 +4520,10 @@
       }
     },
     "fetch-blob": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "optional": true,
       "requires": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -6097,7 +6101,8 @@
     "web-streams-polyfill": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
-      "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q=="
+      "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q==",
+      "optional": true
     },
     "which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,7 @@
         "node": ">=14.8.0"
       },
       "optionalDependencies": {
-        "fetch-blob": "^3.2.0",
-        "web-streams-polyfill": "^3.1.1"
+        "fetch-blob": "^3.2.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,6 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "*",
-        "node-domexception": "^1.0.0"
-      },
       "devDependencies": {
         "@types/filesystem": "^0.0.32",
         "rollup": "^2.67.3",
@@ -2191,6 +2187,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -5176,7 +5173,8 @@
     "node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "optional": true
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
   ],
   "homepage": "https://github.com/jimmywarting/native-file-system-adapter#readme",
   "optionalDependencies": {
+    "fetch-blob": "^3.2.0",
     "web-streams-polyfill": "^3.1.1"
   },
   "dependencies": {
-    "fetch-blob": "^3.1.5",
     "node-domexception": "^1.0.0"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
   ],
   "homepage": "https://github.com/jimmywarting/native-file-system-adapter#readme",
   "optionalDependencies": {
-    "fetch-blob": "^3.2.0",
-    "web-streams-polyfill": "^3.1.1"
+    "fetch-blob": "^3.2.0"
   },
   "standard": {
     "globals": [

--- a/package.json
+++ b/package.json
@@ -52,9 +52,6 @@
     "fetch-blob": "^3.2.0",
     "web-streams-polyfill": "^3.1.1"
   },
-  "dependencies": {
-    "node-domexception": "^1.0.0"
-  },
   "standard": {
     "globals": [
       "File",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native-file-system-adapter",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "description": "Native File System API",
   "main": "src/es6.js",
   "module": "./src/es6.js",

--- a/src/FileSystemWritableFileStream.js
+++ b/src/FileSystemWritableFileStream.js
@@ -1,8 +1,8 @@
-/** @type {typeof WritableStream} */
-const ws = globalThis.WritableStream || await import('https://cdn.jsdelivr.net/npm/web-streams-polyfill@3/dist/ponyfill.es2018.mjs').then(r => r.WritableStream).catch(() => import('web-streams-polyfill').then(r => r.WritableStream))
+import config from './config.js'
 
-// TODO: add types for ws
-class FileSystemWritableFileStream extends ws {
+const { WritableStream } = config
+
+class FileSystemWritableFileStream extends WritableStream {
   constructor (...args) {
     super(...args)
 

--- a/src/adapters/downloader.js
+++ b/src/adapters/downloader.js
@@ -1,12 +1,18 @@
 /* global Blob, DOMException, Response, MessageChannel */
 
 import { errors } from '../util.js'
+import config from '../config.js'
+
+const {
+  WritableStream,
+  TransformStream,
+  DOMException,
+  Blob
+} = config
 
 const { GONE } = errors
 // @ts-ignore
 const isSafari = /constructor/i.test(window.HTMLElement) || window.safari || window.WebKitPoint
-let TransformStream = globalThis.TransformStream
-let WritableStream = globalThis.WritableStream
 
 export class FileHandle {
   constructor (name = 'unkown') {
@@ -26,12 +32,6 @@ export class FileHandle {
    * @param {object} [options={}]
    */
   async createWritable (options = {}) {
-    if (!TransformStream) {
-      // @ts-ignore
-      const ponyfill = await import('https://cdn.jsdelivr.net/npm/web-streams-polyfill@3/dist/ponyfill.es2018.mjs')
-      TransformStream = ponyfill.TransformStream
-      WritableStream = ponyfill.WritableStream
-    }
     const sw = await navigator.serviceWorker?.getRegistration()
     const link = document.createElement('a')
     const ts = new TransformStream()

--- a/src/adapters/memory.js
+++ b/src/adapters/memory.js
@@ -1,9 +1,7 @@
 import { errors } from '../util.js'
-/** @type {typeof window.File} */
-const File = globalThis.File || await import('fetch-blob/file.js').then(m => m.File)
-/** @type {typeof window.Blob} */
-const Blob = globalThis.Blob || await import('fetch-blob').then(m => m.Blob)
+import config from '../config.js'
 
+const { File, Blob, DOMException } = config
 const { INVALID, GONE, MISMATCH, MOD_ERR, SYNTAX, SECURITY, DISALLOWED } = errors
 
 export class Sink {

--- a/src/adapters/node.js
+++ b/src/adapters/node.js
@@ -1,6 +1,5 @@
 import fs from 'node:fs/promises'
 import { join } from 'node:path'
-import 'node-domexception'
 import { errors } from '../util.js'
 
 const { INVALID, GONE, MISMATCH, MOD_ERR, SYNTAX } = errors

--- a/src/adapters/node.js
+++ b/src/adapters/node.js
@@ -2,6 +2,12 @@ import fs from 'node:fs/promises'
 import { join } from 'node:path'
 import { errors } from '../util.js'
 
+import config from '../config.js'
+
+const {
+  DOMException
+} = config
+
 const { INVALID, GONE, MISMATCH, MOD_ERR, SYNTAX } = errors
 
 /**
@@ -115,8 +121,8 @@ export class FileHandle {
       if (err.code === 'ENOENT') throw new DOMException(...GONE)
     })
 
+    // TODO: replace once https://github.com/nodejs/node/issues/37340 is fixed
     const { fileFrom } = await import('fetch-blob/from.js')
-
     return fileFrom(this._path)
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,10 @@
+const config = {
+  ReadableStream: globalThis.ReadableStream,
+  WritableStream: globalThis.WritableStream,
+  TransformStream: globalThis.TransformStream,
+  DOMException: globalThis.DOMException,
+  Blob: globalThis.Blob,
+  File: globalThis.File,
+}
+
+export default config

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -1,6 +1,8 @@
 import { existsSync, mkdirSync, rmdirSync } from 'node:fs'
-import { getOriginPrivateDirectory } from '../src/es6.js'
+import config from '../src/config.js'
 import steps from './test.js'
+import File from 'fetch-blob/file.js'
+import { getOriginPrivateDirectory } from '../src/es6.js'
 import { cleanupSandboxedFileSystem } from '../test/util.js'
 
 let hasFailures = false
@@ -12,6 +14,7 @@ async function test (fs, step, root) {
     console.log(`[OK]: ${fs} ${step.desc}`)
   } catch (err) {
     console.log(`[ERR]: ${fs} ${step.desc}\n\t-> ${err.message}`)
+    console.error(err.stack)
     hasFailures = true
   }
 }
@@ -21,6 +24,7 @@ async function start () {
   if (!existsSync(testFolderPath)) {
     mkdirSync(testFolderPath)
   }
+  config.File = File
   const root = await getOriginPrivateDirectory(import('../src/adapters/node.js'), './testfolder')
   const memory = await getOriginPrivateDirectory(import('../src/adapters/memory.js'))
 


### PR DESCRIPTION
some ppl have had issues with top level await and my way of loading stream polyfills from a CDN

This will totally remove all top level await and dependency on `fetch-blob` and web stream polyfills and making it zero dependent on any other library. considering now that all green env now has WritableStream, ReadableStream, TransformStream, Blob, File, and DOMException globally now.

right now if you want to use it in NodeJS and want to get a File class from `handle.getFile()` then you would have to install the optional dependency of `fetch-blob` in order to use the `fileFrom(path)` also

However if you depend on some older environment then there is an option to do so using the config

```js
import config from 'native-file-system-adapter/config.js'
const config = {
  ReadableStream: globalThis.ReadableStream,
  WritableStream: globalThis.WritableStream,
  TransformStream: globalThis.TransformStream,
  DOMException: globalThis.DOMException,
  Blob: globalThis.Blob,
  File: globalThis.File,
}
```

closes #36 
closes #20