### PR TITLE
Fix the filed name in `showSaveFilePicker` options

### DIFF
--- a/src/showSaveFilePicker.js
+++ b/src/showSaveFilePicker.js
@@ -5,7 +5,7 @@ const native = globalThis.showSaveFilePicker
 /**
  * @param {Object} [options]
  * @param {boolean} [options.excludeAcceptAllOption=false] Prevent user for selecting any
- * @param {Object[]} [options.accepts] Files you want to accept
+ * @param {Object[]} [options.types] Files you want to accept
  * @param {string} [options.suggestedName] the name to fall back to when using polyfill
  * @param {string} [options._name] the name to fall back to when using polyfill
  * @param {boolean} [options._preferPolyfill] If you rather want to use the polyfill instead of the native

--- a/types/src/adapters/memory.d.ts
+++ b/types/src/adapters/memory.d.ts
@@ -43,4 +43,3 @@ export class FolderHandle {
 }
 declare function _default(): FolderHandle;
 export default _default;
-declare const File_1: typeof window.File;

--- a/types/src/config.d.ts
+++ b/types/src/config.d.ts
@@ -1,0 +1,52 @@
+export default config;
+declare namespace config {
+    const ReadableStream: {
+        new <R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
+        prototype: ReadableStream<any>;
+    };
+    const WritableStream: {
+        new <W = any>(underlyingSink?: UnderlyingSink<W>, strategy?: QueuingStrategy<W>): WritableStream<W>;
+        prototype: WritableStream<any>;
+    };
+    const TransformStream: {
+        new <I = any, O = any>(transformer?: Transformer<I, O>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<O>): TransformStream<I, O>;
+        prototype: TransformStream<any, any>;
+    };
+    const DOMException: {
+        new (message?: string, name?: string): DOMException;
+        prototype: DOMException;
+        readonly ABORT_ERR: number;
+        readonly DATA_CLONE_ERR: number;
+        readonly DOMSTRING_SIZE_ERR: number;
+        readonly HIERARCHY_REQUEST_ERR: number;
+        readonly INDEX_SIZE_ERR: number;
+        readonly INUSE_ATTRIBUTE_ERR: number;
+        readonly INVALID_ACCESS_ERR: number;
+        readonly INVALID_CHARACTER_ERR: number;
+        readonly INVALID_MODIFICATION_ERR: number;
+        readonly INVALID_NODE_TYPE_ERR: number;
+        readonly INVALID_STATE_ERR: number;
+        readonly NAMESPACE_ERR: number;
+        readonly NETWORK_ERR: number;
+        readonly NOT_FOUND_ERR: number;
+        readonly NOT_SUPPORTED_ERR: number;
+        readonly NO_DATA_ALLOWED_ERR: number;
+        readonly NO_MODIFICATION_ALLOWED_ERR: number;
+        readonly QUOTA_EXCEEDED_ERR: number;
+        readonly SECURITY_ERR: number;
+        readonly SYNTAX_ERR: number;
+        readonly TIMEOUT_ERR: number;
+        readonly TYPE_MISMATCH_ERR: number;
+        readonly URL_MISMATCH_ERR: number;
+        readonly VALIDATION_ERR: number;
+        readonly WRONG_DOCUMENT_ERR: number;
+    };
+    const Blob: {
+        new (blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
+        prototype: Blob;
+    };
+    const File: {
+        new (fileBits: BlobPart[], fileName: string, options?: FilePropertyBag): File;
+        prototype: File;
+    };
+}

--- a/types/src/showSaveFilePicker.d.ts
+++ b/types/src/showSaveFilePicker.d.ts
@@ -2,7 +2,7 @@ export default showSaveFilePicker;
 export type FileSystemFileHandle = import('./FileSystemFileHandle.js').default;
 export function showSaveFilePicker(options?: {
     excludeAcceptAllOption?: boolean;
-    accepts?: any[];
+    types?: any[];
     suggestedName?: string;
     _name?: string;
     _preferPolyfill?: boolean;


### PR DESCRIPTION
Now `types` is the correct field name, not `accepts`.
https://developer.mozilla.org/en-US/docs/Web/API/Window/showSaveFilePicker#parameters