### PR TITLE
handle the cancellation by the user

### DIFF
--- a/src/showOpenFilePicker.js
+++ b/src/showOpenFilePicker.js
@@ -41,11 +41,15 @@ async function showOpenFilePicker (options = {}) {
   // Lazy load while the user is choosing the directory
   const p = import('./util.js')
 
-  await new Promise(resolve => {
-    input.addEventListener('change', resolve, { once: true })
-    input.click()
-  })
-  input.remove()
+  try {
+    await new Promise((resolve, reject) => {
+      input.addEventListener('change', resolve, { once: true })
+      input.addEventListener('cancel', reject, { once: true })
+      input.click()
+    })
+  } finally {
+    input.remove()
+  }
 
   return p.then(m => m.getFileHandlesFromInput(input))
 }


### PR DESCRIPTION
<!-- Thanks for contributing! ❤️ -->
If '_preferPolyfill = true' and the input element never gets a change because the user has pressed the cancle button, the promise will never be resolved. Therefore I have now added the cancle event. Since this gives an error, the try finally is necessary to remove the input correctly.