### PR TITLE
Types: add 'size' to createWritable options

### DIFF
--- a/types/src/FileSystemFileHandle.d.ts
+++ b/types/src/FileSystemFileHandle.d.ts
@@ -3,6 +3,7 @@ export class FileSystemFileHandle extends FileSystemHandle {
     constructor(adapter: any);
     createWritable(options?: {
         keepExistingData?: boolean;
+        size?: number;
     }): Promise<FileSystemWritableFileStream>;
     getFile(): Promise<File>;
     [kAdapter]: any;


### PR DESCRIPTION
The optional `size` property in createWritable [is used by the downloader adapter](https://github.com/jimmywarting/native-file-system-adapter/blob/d1a158f76f76aff71e586152e44ad4b9c5e8045d/src/adapters/downloader.js#L62), so it should be added to the types.