### PR TITLE
fix: prevent service worker from being killed by the browser

### DIFF
--- a/src/adapters/downloader.js
+++ b/src/adapters/downloader.js
@@ -62,7 +62,7 @@ export class FileHandle {
         ...(options.size ? { 'content-length': options.size } : {})
       }
 
-      const keepAlive = setTimeout(() => sw.active.postMessage(0), 10000)
+      const keepAlive = setInterval(() => sw.active.postMessage(0), 10000)
 
       ts.readable.pipeThrough(new TransformStream({
         transform (chunk, ctrl) {


### PR DESCRIPTION
Fix bug described in #77 causing downloads to fail on some browsers.
On Firefox this results in a download failing around 40 seconds after starting.