### PR TITLE
Add cancel handling and cleanup to pickers

### DIFF
--- a/src/showDirectoryPicker.js
+++ b/src/showDirectoryPicker.js
@@ -27,10 +27,17 @@ async function showDirectoryPicker (options = {}) {
   // Lazy load while the user is choosing the directory
   const p = import('./util.js')
 
-  await new Promise(resolve => {
-    input.addEventListener('change', resolve)
+  const evt = await new Promise(resolve => {
+    input.onchange = input.onchange = resolve
     input.click()
   })
+
+  input.onchange = input.onchange = null
+  input.remove()
+
+  if (evt.type === 'cancel') {
+    throw new DOMException("Failed to execute 'showDirectoryPicker' on 'file input': The user aborted a request.", 'AbortError')
+  }
 
   return p.then(mod => mod.getDirHandlesFromInput(input))
 }

--- a/src/showOpenFilePicker.js
+++ b/src/showOpenFilePicker.js
@@ -41,11 +41,17 @@ async function showOpenFilePicker (options = {}) {
   // Lazy load while the user is choosing the directory
   const p = import('./util.js')
 
-  await new Promise(resolve => {
-    input.addEventListener('change', resolve, { once: true })
+  const evt = await new Promise(resolve => {
+    input.onchange = input.onchange = resolve
     input.click()
   })
+
+  input.onchange = input.onchange = null
   input.remove()
+
+  if (evt.type === 'cancel') {
+    throw new DOMException("Failed to execute 'showOpenFilePicker' on 'file input': The user aborted a request.", 'AbortError')
+  }
 
   return p.then(m => m.getFileHandlesFromInput(input))
 }


### PR DESCRIPTION
Use the input.onchange handler to capture the change event, store the event (evt), clear the handler and remove the input element in both showDirectoryPicker and showOpenFilePicker. If the event type is 'cancel', throw a DOMException AbortError to signal user-aborted selection. This replaces the previous addEventListener usage, ensures proper cleanup of the input/handler, and preserves lazy-loading of util functions before returning handles.

closes #71

<!-- Thanks for contributing! ❤️ -->
