### PR TITLE
Add agent docs and Copilot workspace instructions

### DIFF
--- a/.github/agents/spec-traceability.agent.md
+++ b/.github/agents/spec-traceability.agent.md
@@ -1,0 +1,110 @@
+# Spec Traceability Agent
+
+**When to use:** Checking whether a specific WHATWG File System spec operation is correctly implemented, finding which adapters are missing a behavior, or before starting work on a new spec section.
+
+## Workflow
+
+### Step 1: Identify the Spec Section
+
+The WHATWG File System Access spec is at: https://fs.spec.whatwg.org/
+
+Key sections:
+- [FileSystemHandle removal](https://fs.spec.whatwg.org/#dom-filesystemhandle-remove)
+- [FileSystemDirectoryHandle.getDirectoryHandle](https://fs.spec.whatwg.org/#dictdef-filesystemgetdirectoryhandleoptions)
+- [FileSystemDirectoryHandle.getFileHandle](https://fs.spec.whatwg.org/#dictdef-filesystemgetfilehandleoptions)
+- [FileSystemWritableFileStream.write](https://fs.spec.whatwg.org/#dictdef-filesystemwriteparams)
+- [FileSystemDirectoryHandle.removeEntry](https://fs.spec.whatwg.org/#dictdef-filesystemremoveoptions)
+
+### Step 2: Map Spec Algorithm to Implementation
+
+Read the implementation files:
+
+```bash
+# Polyfill wrappers
+cat src/FileSystemHandle.js      # remove() method
+cat src/FileSystemDirectoryHandle.js  # getDirectoryHandle, getFileHandle, removeEntry
+cat src/FileSystemFileHandle.js   # getFile, createWritable
+
+# Adapters
+cat src/adapters/memory.js       # Ground truth implementation
+cat src/adapters/node.js         # Node.js fs
+cat src/adapters/deno.js         # Deno fs
+cat src/adapters/indexeddb.js     # IndexedDB
+cat src/adapters/cache.js         # Cache API
+```
+
+### Step 3: Extract Error Constants
+
+```bash
+cat src/util.js
+```
+
+Error mapping:
+```javascript
+INVALID: ['seeking position failed.', 'InvalidStateError']
+GONE: ['A requested file or directory could not be found...', 'NotFoundError']
+MISMATCH: ['The path supplied exists, but was not...', 'TypeMismatchError']
+MOD_ERR: ['The object can not be modified in this way.', 'InvalidModificationError']
+SYNTAX: m => ['Failed to execute...', 'SyntaxError']
+DISALLOWED: ['The request is not allowed...', 'NotAllowedError']
+```
+
+### Step 4: Create Coverage Table
+
+For each spec step, document:
+
+| Spec Step | memory.js | node.js | deno.js | indexeddb.js | cache.js | Notes |
+|-----------|-----------|---------|---------|--------------|----------|-------|
+| `remove()` throws NotFoundError if gone | ✓ | ✓ | ✓ | ✓ | ✓ | |
+| `remove()` on non-empty dir (no recursive) | ✓ | ✓ | ✓ | ✓ | ✓ | |
+| `remove()` on dir with open writable | ✗ | ✗ | ✗ | ✗ | ✗ | Known gap |
+| `createWritable(keepExistingData: false)` truncates | ✓ | ✓ | ✓ | ✓ | ✓ | |
+| `write()` with position > size pads | ✓ | ✓ | ✓ | ✓ | ✓ | |
+
+### Step 5: Flag Deviations
+
+Mark any step that:
+1. Throws wrong error type
+2. Skips validation entirely
+3. Has incorrect atomicity semantics
+4. Missing edge case handling
+
+Example flags:
+```
+[WRONG ERROR] node.js: Sink.write() throws SyntaxError instead of TypeError for invalid position
+[SKIP] deno.js: FolderHandle.remove() doesn't check for open writables
+[ATOMICITY] node.js: createWritable({keepExistingData: false}) doesn't truncate atomically
+```
+
+## Coverage Matrix Template
+
+Copy this template when starting a new spec section analysis:
+
+```markdown
+## [Spec Section Name]
+
+Spec: https://fs.spec.whatwg.org/#[anchor]
+
+### Algorithm Steps
+
+| Step | Description | memory | node | deno | idb | cache |
+|------|-------------|--------|------|------|-----|-------|
+| 1 | [Step description] | ✓/✗ | ✓/✗ | ✓/✗ | ✓/✗ | ✓/✗ | Notes |
+| 2 | ... | | | | | | |
+
+### Deviations
+
+- **[ADAPTER]**: [Issue description]
+```
+
+## Quick Reference: Spec → Adapter Method Mapping
+
+| Spec Operation | Wrapper Method | Adapter Method |
+|---------------|----------------|----------------|
+| `FileSystemHandle.remove()` | `FileSystemHandle.remove()` | `remove()` |
+| `FileSystemDirectoryHandle.getDirectoryHandle()` | `getDirectoryHandle()` | `getDirectoryHandle()` |
+| `FileSystemDirectoryHandle.getFileHandle()` | `getFileHandle()` | `getFileHandle()` |
+| `FileSystemDirectoryHandle.removeEntry()` | `removeEntry()` | `removeEntry()` |
+| `FileSystemDirectoryHandle.resolve()` | `resolve()` | (wrapper only) |
+| `FileSystemFileHandle.getFile()` | `getFile()` | `getFile()` |
+| `FileSystemFileHandle.createWritable()` | `createWritable()` | `createWritable()` |

--- a/.github/agents/wpt-triage.agent.md
+++ b/.github/agents/wpt-triage.agent.md
@@ -1,0 +1,116 @@
+# WPT Triage Agent
+
+**When to use:** Analyzing failing WPT subtests, minimizing WPT failures to root causes in adapter code, determining if a WPT failure belongs in the expected-failures allowlist or should be fixed.
+
+## Workflow
+
+### Step 1: Establish Baseline
+
+Run the test suite to identify which tests are failing:
+
+```bash
+npm run test:wpt-node
+```
+
+### Step 2: Read Current Allowlist
+
+```bash
+cat test/wpt-expected-failures.json
+```
+
+Check if the failure is already listed. If it is, the failure is a known issue.
+
+### Step 3: Read the Failing WPT Script
+
+```bash
+cat wpt/fs/script-tests/<script-name>.js
+```
+
+Identify:
+- Which `directory_test` or `promise_test` is failing
+- What assertion is being made
+- What adapter methods are called
+
+### Step 4: Map to Adapter Method
+
+Use this reference:
+
+| WPT Script | Adapter Method(s) |
+|------------|-------------------|
+| `FileSystemBaseHandle-remove.js` | `remove()` |
+| `FileSystemDirectoryHandle-getDirectoryHandle.js` | `getDirectoryHandle()` |
+| `FileSystemDirectoryHandle-getFileHandle.js` | `getFileHandle()` |
+| `FileSystemDirectoryHandle-iteration.js` | `entries()` |
+| `FileSystemDirectoryHandle-removeEntry.js` | `removeEntry()` |
+| `FileSystemFileHandle-getFile.js` | `getFile()` |
+| `FileSystemWritableFileStream*.js` | `createWritable()`, `Sink.write()`, `Sink.close()` |
+
+### Step 5: Read the Adapter Implementation
+
+```bash
+# For memory adapter (ground truth)
+cat src/adapters/memory.js
+
+# For node adapter
+cat src/adapters/node.js
+
+# For deno adapter
+cat src/adapters/deno.js
+```
+
+### Step 6: Check Spec Accuracy
+
+Reference: https://fs.spec.whatwg.org/
+
+Common spec behaviors:
+- `remove()` on directory with open writable → `NoModificationAllowedError`
+- `remove()` on non-empty directory (non-recursive) → `InvalidModificationError`
+- `getFileHandle()` for existing file → return same handle
+- `getDirectoryHandle()` for existing dir → return same handle
+- `createWritable({keepExistingData: false})` → truncate file first
+
+### Step 7: Determine Fix or Allowlist
+
+**If fixable:**
+1. Make minimal change to the relevant adapter
+2. Re-run `npm run test:wpt-node`
+3. Verify the test passes
+
+**If not fixable (e.g., test harness limitation, spec deviation):**
+Add entry to `test/wpt-expected-failures.json`:
+
+```json
+{
+  "ScriptName.js": [
+    {
+      "name": "Exact test description",
+      "reason": "Clear explanation of why this fails"
+    }
+  ]
+}
+```
+
+## Common Failure Patterns
+
+| Error Pattern | Likely Cause | Fix |
+|---------------|--------------|-----|
+| `Promise resolves but should reject` | Missing check or wrong error thrown | Add proper validation and throw correct `DOMException` |
+| `TypeError` instead of `DOMException` | Using native Error | Wrap with `throw new DOMException(...)` |
+| `InvalidModificationError` instead of `NoModificationAllowedError` | Wrong error constant | Check `src/util.js` error mapping |
+| Size overcounting on overwrite | Unconditional size += | Use `Math.max(this._size, position + bytesWritten)` |
+| Parent removed but write succeeds | No parent existence check | Track parent path and check before writes |
+
+## Example Triage
+
+**Failure:** `remove() to remove an empty directory` fails with `EISDIR`
+
+**Analysis:**
+1. Read WPT script: Test calls `dir.remove()` on an empty directory
+2. Read node adapter: Uses `fs.rm()` for directory removal
+3. Problem: `fs.rm()` with `recursive: false` throws `EISDIR` on directories
+4. Fix: Use `fs.rmdir()` for non-recursive directory removal
+
+**Output:**
+- Root cause: `fs.rm()` is wrong for non-recursive directory removal
+- Fix: Change to `fs.rmdir()` with proper error mapping
+- Test after fix: Verify test passes

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,102 @@
+# Native File System Adapter — Copilot Workspace Instructions
+
+## Project Overview
+
+This is a WHATWG File System Access API polyfill. It provides browser-compatible `FileSystemHandle`, `FileSystemDirectoryHandle`, and `FileSystemFileHandle` interfaces backed by various storage backends (memory, Node.js fs, Deno fs, IndexedDB, Cache API, jsDelivr CDN).
+
+## Adapter Contract
+
+Every adapter in `src/adapters/` must implement the following interface. The polyfill wraps these adapters with `FileSystemDirectoryHandle` / `FileSystemFileHandle` which call adapter methods directly.
+
+### Directory Handle Methods
+
+| Method | Signature | Notes |
+|--------|-----------|-------|
+| `entries()` | `async *entries(): AsyncGenerator<[string, FileHandle \| FolderHandle]>` | Yields `[name, handle]` pairs |
+| `getDirectoryHandle(name, opts)` | `opts: { create?: boolean }` | Returns `FolderHandle` or throws |
+| `getFileHandle(name, opts)` | `opts: { create?: boolean }` | Returns `FileHandle` or throws |
+| `removeEntry(name, opts)` | `opts: { recursive?: boolean }` | Recursively removes entries |
+| `remove(options)` | `options: { recursive?: boolean }` | Removes this directory (must delete from parent) |
+| `isSameEntry(other)` | `other: FolderHandle` | Compares by identity or path |
+
+### File Handle Methods
+
+| Method | Signature | Notes |
+|--------|-----------|-------|
+| `getFile()` | `async getFile(): Promise<File>` | Returns a File/Blob |
+| `createWritable(opts)` | `opts: { keepExistingData?: boolean }` | Returns a `Sink` (writable stream) |
+| `remove()` | `async remove()` | Removes this file (must delete from parent) |
+| `isSameEntry(other)` | `other: FileHandle` | Compares by identity or path |
+
+### Sink (Writable Stream) Interface
+
+| Method | Signature | Notes |
+|--------|-----------|-------|
+| `write(chunk)` | `chunk: Uint8Array \| Buffer \| string \| Blob \| WriteParams` | Write data |
+| `close()` | `async close()` | Finalize and commit |
+| `abort()` | `async abort()` | Cancel and discard |
+
+Write params:
+- `{ type: 'write', data: ..., position?: number }`
+- `{ type: 'seek', position: number }`
+- `{ type: 'truncate', size: number }`
+
+## Error Name Mapping
+
+**Always use `DOMException` with these exact names.** Import from `src/util.js`:
+
+```javascript
+import { errors } from '../util.js'
+const { INVALID, GONE, MISMATCH, MOD_ERR, SYNTAX, SECURITY, DISALLOWED } = errors
+```
+
+| Name | Message | When to throw |
+|------|---------|---------------|
+| `NotFoundError` | "A requested file or directory could not be found..." | Entry doesn't exist, parent removed |
+| `TypeMismatchError` | "The path supplied exists, but was not an entry of requested type." | File exists when directory expected |
+| `InvalidModificationError` | "The object can not be modified in this way." | Non-empty dir remove, ENOTEMPTY |
+| `InvalidStateError` | "seeking position failed." | Seek past EOF |
+| `SyntaxError` | "Failed to execute 'write'..." | Invalid write params |
+| `NotAllowedError` | "The request is not allowed..." | Read-only adapter (jsdelivr) |
+| `SecurityError` | "It was determined that certain files are unsafe..." | Reserved |
+
+Usage: `throw new DOMException(...GONE)` — GONE is an array `[message, name]`.
+
+## WPT Script → Adapter Method Coverage Matrix
+
+| WPT Script | Adapter Methods Tested | Known Issues |
+|------------|----------------------|--------------|
+| `FileSystemDirectoryHandle-getDirectoryHandle.js` | `getDirectoryHandle()` | Path separator validation |
+| `FileSystemDirectoryHandle-getFileHandle.js` | `getFileHandle()` | Path separator validation |
+| `FileSystemDirectoryHandle-iteration.js` | `entries()` | — |
+| `FileSystemDirectoryHandle-removeEntry.js` | `removeEntry()` | Open writable tracking |
+| `FileSystemDirectoryHandle-resolve.js` | `resolve()` (via wrapper) | — |
+| `FileSystemFileHandle-getFile.js` | `getFile()` | Filename preservation |
+| `FileSystemWritableFileStream.js` | `createWritable()`, `Sink.write()`, `Sink.close()` | Atomic semantics |
+| `FileSystemWritableFileStream-write.js` | `Sink.write()` | Null data handling |
+| `FileSystemWritableFileStream-piped.js` | `ReadableStream.pipeTo()` | Node.js streaming |
+| `FileSystemBaseHandle-isSameEntry.js` | `isSameEntry()` | Memory adapter identity |
+| `FileSystemBaseHandle-remove.js` | `remove()` | Open writable tracking |
+
+## Before Touching an Adapter
+
+1. Run `npm run test:wpt-node` to establish baseline
+2. Read the failing WPT script: `wpt/fs/script-tests/<name>.js`
+3. Identify which adapter method is tested
+4. Read the spec: https://fs.spec.whatwg.org/
+5. Make minimal fix
+6. Re-run tests before committing
+
+## Key Files
+
+- `src/util.js` — Error definitions and utilities
+- `src/FileSystemHandle.js` — Base handle wrapper (calls `adapter.remove()`)
+- `src/FileSystemDirectoryHandle.js` — Directory handle wrapper
+- `src/FileSystemFileHandle.js` — File handle wrapper
+- `src/adapters/memory.js` — In-memory adapter (ground truth)
+- `src/adapters/node.js` — Node.js fs adapter
+- `src/adapters/deno.js` — Deno fs adapter
+- `src/adapters/indexeddb.js` — IndexedDB adapter
+- `src/adapters/cache.js` — Cache API adapter
+- `src/adapters/jsdelivr.js` — Read-only jsDelivr CDN adapter
+- `test/wpt-expected-failures.json` — Known failures by script


### PR DESCRIPTION
Add three documentation files to .github: .github/agents/spec-traceability.agent.md (workflow for mapping WHATWG FS spec to adapter implementations, error extraction, coverage matrix and deviation flags), .github/agents/wpt-triage.agent.md (WPT failure triage workflow, allowlist guidance, common failure patterns and example fixes), and .github/copilot-instructions.md (adapter contract, Sink interface, error name mappings, WPT coverage matrix and development/testing guidance). These provide guidance for triaging tests, ensuring spec traceability, and contributing adapter implementations.

<!-- Thanks for contributing! ❤️ -->
