### PR TITLE
fix: onchange assigned twice instead of oncancel in picker polyfill

### DIFF
--- a/src/showDirectoryPicker.js
+++ b/src/showDirectoryPicker.js
@@ -35,11 +35,11 @@ async function showDirectoryPicker (options = {}) {
   const p = import('./util.js')
 
   const evt = await new Promise(resolve => {
-    input.onchange = input.onchange = resolve
+    input.onchange = input.oncancel = resolve
     input.click()
   })
 
-  input.onchange = input.onchange = null
+  input.onchange = input.oncancel = null
   input.remove()
 
   if (evt.type === 'cancel') {

--- a/src/showOpenFilePicker.js
+++ b/src/showOpenFilePicker.js
@@ -49,11 +49,11 @@ async function showOpenFilePicker (options = {}) {
   const p = import('./util.js')
 
   const evt = await new Promise(resolve => {
-    input.onchange = input.onchange = resolve
+    input.onchange = input.oncancel = resolve
     input.click()
   })
 
-  input.onchange = input.onchange = null
+  input.onchange = input.oncancel = null
   input.remove()
 
   if (evt.type === 'cancel') {


### PR DESCRIPTION
## Problem

In `showOpenFilePicker.js` and `showDirectoryPicker.js`, the cancel handler is never subscribed due to a typo — `onchange` is assigned twice instead of assigning both `onchange` and `oncancel`:

```js
// before — oncancel never assigned
input.onchange = input.onchange = resolve
```

This means cancelling the file picker never resolves the internal Promise, causing it to hang indefinitely. Any code awaiting the picker (e.g. via `async`/`await`) is permanently stuck for the rest of the session.

This affects all browsers that don't implement the native File System Access API and fall back to the `<input type="file">` polyfill — most notably Firefox.

## Fix

```js
// after — both change and cancel resolve the promise
input.onchange = input.oncancel = resolve
```

Also corrected the matching cleanup line (`onchange = onchange = null` → `onchange = oncancel = null`).

## Affected files

- `src/showOpenFilePicker.js`
- `src/showDirectoryPicker.js`

## Verified

Confirmed in [Avalonia](https://github.com/AvaloniaUI/Avalonia) (a cross-platform .NET UI framework that depends on this polyfill for its browser/WASM backend): before this fix, cancelling an open-file or open-folder dialog in Firefox permanently disabled any button bound to the picker for the rest of the session. After this fix the dialog resolves correctly and the button remains functional.