### PR TITLE
work around iOS Safari file extension bug

### DIFF
--- a/src/adapters/downloader.js
+++ b/src/adapters/downloader.js
@@ -153,6 +153,9 @@ export class FileHandle {
     // Make filename RFC5987 compatible
     const fileName = encodeURIComponent(this.name).replace(/['()]/g, escape).replace(/\*/g, '%2A')
     const headers = {
+      // Prevent MIME sniffing. On iOS 26+, this works around a Safari bug
+      // that can cause files to be saved with an additional `.html` extension.
+      'x-content-type-options': 'nosniff',
       'content-disposition': "attachment; filename*=UTF-8''" + fileName,
       'content-type': 'application/octet-stream; charset=utf-8',
       ...(options.size ? { 'content-length': options.size } : {})


### PR DESCRIPTION
Implement the workaround discussed in #103 using the `X-Content-Type-Options: nosniff` header to resolve the issue on iOS 26+
